### PR TITLE
don't recommend sudo, add npm install to test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,14 +150,16 @@ A cleanup handler should never call `process.exit()`. If a handler prevents a si
 This module includes an extensive test suite. You can run it from the module directory with either the [`tap`](http://www.node-tap.org/basics/) or [`subtap`](https://github.com/jtlapp/subtap) test runner, as follows:
 
 ```
-sudo npm install -g tap
+npm install -g tap
+npm install
 tap tests/*.js
 ```
 
 or
 
 ```
-sudo npm install -g subtap
+npm install -g subtap
+npm install
 subtap
 ```
 


### PR DESCRIPTION
It's not a good idea to recommend using sudo to `npm install -g` as it can cause permission issues. If the user can't install it without sudo they can then try it themselves. Npm itself does recommend avoiding use of sudo as well.

Also added `npm install` to the test commands since it actually needs to be run locally before tap will work.

```
module.js:472
    throw err;
    ^

Error: Cannot find module 'tap'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/xo/code/node-cleanup/tests/multiple.js:3:9)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
```